### PR TITLE
fix: daily-issue-open.yml YAML 문법 오류 수정

### DIFF
--- a/.github/workflows/daily-issue-open.yml
+++ b/.github/workflows/daily-issue-open.yml
@@ -27,27 +27,29 @@ jobs:
           script: |
             const today = '${{ steps.date.outputs.today }}';
             const title = `📝 Daily TIL - ${today}`;
-            const body = `## 📅 Today's Learning
-            
-Date: ${today}
-
-### ✍️ What I learned today:
-- [ ] 학습 내용 1
-- [ ] 학습 내용 2
-- [ ] 학습 내용 3
-
-### 📚 Resources:
-- 자료 링크 1
-- 자료 링크 2
-
-### 🎯 Tomorrow's Goal:
-- 내일 공부할 내용 작성
-
-### 💡 Notes:
-자유롭게 메모 작성
-
----
-*This issue was automatically created for today's learning log.*`;
+            const body = [
+              `## 📅 Today's Learning`,
+              ``,
+              `Date: ${today}`,
+              ``,
+              `### ✍️ What I learned today:`,
+              `- [ ] 학습 내용 1`,
+              `- [ ] 학습 내용 2`,
+              `- [ ] 학습 내용 3`,
+              ``,
+              `### 📚 Resources:`,
+              `- 자료 링크 1`,
+              `- 자료 링크 2`,
+              ``,
+              `### 🎯 Tomorrow's Goal:`,
+              `- 내일 공부할 내용 작성`,
+              ``,
+              `### 💡 Notes:`,
+              `자유롭게 메모 작성`,
+              ``,
+              `---`,
+              `*This issue was automatically created for today's learning log.*`
+            ].join('\n');
             
             const issue = await github.rest.issues.create({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- daily-issue-open.yml 파일의 YAML 문법 오류 수정
- 멀티라인 템플릿 리터럴(``)이 YAML 파서와 충돌하는 문제 해결
- 배열 + join('\n') 방식으로 변경

## 원인
34번째 줄에서 YAML 파서가 템플릿 리터럴 내부의 들여쓰기를 잘못 해석

## Test plan
- [ ] PR 머지 후 워크플로우 수동 실행 테스트
- [ ] Run workflow 버튼 활성화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)