### PR TITLE
fix: GitHub Actions 날짜 계산을 한국 시간(KST)으로 변경

### DIFF
--- a/.github/workflows/daily-issue-close.yml
+++ b/.github/workflows/daily-issue-close.yml
@@ -17,9 +17,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Get yesterday's date
+      - name: Get yesterday's date (KST)
         id: date
-        run: echo "yesterday=$(date -d 'yesterday' +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "yesterday=$(TZ=Asia/Seoul date -d 'yesterday' +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Find and close yesterday's daily issue
         uses: actions/github-script@v6

--- a/.github/workflows/daily-issue-open.yml
+++ b/.github/workflows/daily-issue-open.yml
@@ -17,9 +17,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Get today's date
+      - name: Get today's date (KST)
         id: date
-        run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "today=$(TZ=Asia/Seoul date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Create daily issue
         uses: actions/github-script@v6


### PR DESCRIPTION
## Summary
- GitHub Actions 워크플로우에서 날짜 계산 시 `TZ=Asia/Seoul` 환경변수 추가
- `daily-issue-open.yml`, `daily-issue-close.yml` 모두 한국 시간 기준으로 날짜 계산

## Test plan
- [x] 워크플로우 수동 실행하여 날짜가 한국 시간 기준으로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)