### PR TITLE
Fix baseurl 깃허브 페이지 주소 수정

### DIFF
--- a/jsc/docusaurus.config.ts
+++ b/jsc/docusaurus.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   favicon: 'img/favicon.ico',
 
   url: 'https://TWLS151.github.io',
-  baseUrl: '/TWL/jsc/',
+  baseUrl: '/TWL/',
 
   organizationName: 'TWLS151',
   projectName: 'TWL',


### PR DESCRIPTION
baseurl 주소 수정
주소가 달라서 githubpage가 깨지는것을 수정했습니다.
깃허브 액션이 main에 합쳐져야 발동이 되어서 잘 될지는 merge해봐야 안다는 사실...
기도메타